### PR TITLE
Update Google AI Studio SDK example to use gateway base URL

### DIFF
--- a/src/content/docs/ai-gateway/providers/google-ai-studio.mdx
+++ b/src/content/docs/ai-gateway/providers/google-ai-studio.mdx
@@ -50,26 +50,32 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_name}/google-ai
       }'
 ```
 
-### Use `@google/generative-ai` with JavaScript
+### Use `@google/genai` with JavaScript
 
-If you are using the `@google/generative-ai` package, you can set your endpoint like this:
+If you are using the `@google/genai` package, you can set your endpoint like this:
 
 ```js title="JavaScript example"
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleGenAI } from "@google/genai";
 
 const api_token = env.GOOGLE_AI_STUDIO_TOKEN;
 const account_id = "";
 const gateway_name = "";
 
-const genAI = new GoogleGenerativeAI(api_token);
-const model = genAI.getGenerativeModel(
-	{ model: "gemini-1.5-flash" },
-	{
-		baseUrl: `https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_name}/google-ai-studio`,
-	},
-);
+const genAI = new GoogleGenAI({
+        apiKey: api_token,
+        httpOptions: {
+                baseUrl: `https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_name}/google-ai-studio`,
+        },
+});
 
-await model.generateContent(["What is Cloudflare?"]);
+const model = "gemini-1.5-flash";
+const prompt = "What is Cloudflare?";
+const response = await genAI.models.generateContent({
+        model,
+        contents: prompt,
+});
+
+console.log(response.text);
 ```
 
 <Render


### PR DESCRIPTION
## Summary
- switch the Google AI Studio JavaScript example to the `@google/genai` SDK
- configure the `GoogleGenAI` client with Cloudflare AI Gateway `baseUrl` and keep the existing prompt logging flow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9d71f5ad8832c8e6091e42862723a