### PR TITLE
Docs: Update Google AI Studio JavaScript example to use @google/genai and new client API

### DIFF
--- a/src/content/docs/ai-gateway/providers/google-ai-studio.mdx
+++ b/src/content/docs/ai-gateway/providers/google-ai-studio.mdx
@@ -50,26 +50,32 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_name}/google-ai
       }'
 ```
 
-### Use `@google/generative-ai` with JavaScript
+### Use `@google/genai` with JavaScript
 
-If you are using the `@google/generative-ai` package, you can set your endpoint like this:
+If you are using the `@google/genai` package, you can set your endpoint like this:
 
 ```js title="JavaScript example"
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleGenAI } from "@google/genai";
 
-const api_token = env.GOOGLE_AI_STUDIO_TOKEN;
+const api_token = process.env.GOOGLE_AI_STUDIO_TOKEN;
 const account_id = "";
 const gateway_name = "";
 
-const genAI = new GoogleGenerativeAI(api_token);
-const model = genAI.getGenerativeModel(
-	{ model: "gemini-1.5-flash" },
-	{
-		baseUrl: `https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_name}/google-ai-studio`,
-	},
-);
+const genAI = new GoogleGenAI({
+        apiKey: api_token,
+        httpOptions: {
+                baseUrl: `https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_name}/google-ai-studio`,
+        },
+});
 
-await model.generateContent(["What is Cloudflare?"]);
+const model = "gemini-1.5-flash";
+const prompt = "What is Cloudflare?";
+const response = await genAI.models.generateContent({
+        model,
+        contents: prompt,
+});
+
+console.log(response.text);
 ```
 
 <Render


### PR DESCRIPTION
### Motivation

- Update the JavaScript example for the Google AI Studio provider to reflect the new official client library and its runtime API shape.
- Ensure the docs show correct environment variable usage and the current method to call model endpoints.

### Description

- Replaced references to the old package `@google/generative-ai` with the new `@google/genai` import and constructor usage.
- Switched environment token retrieval to `process.env.GOOGLE_AI_STUDIO_TOKEN` in the example.
- Rewrote the example from the old `getGenerativeModel` flow to the new `genAI.models.generateContent` call and updated the `httpOptions.baseUrl` configuration. 
- Added a minimal `console.log(response.text)` to illustrate accessing the generated output.

### Testing

- Ran the documentation site build with `yarn build` which completed successfully.
- Ran the linter with `yarn lint` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68c9d71f5ad8832c8e6091e42862723a)